### PR TITLE
Add onBackpressureBuffer to rxFirebase

### DIFF
--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,28 +1,42 @@
 {
   "project_info": {
-    "project_id": "mockproject-1234",
-    "project_number": "123456789000",
-    "name": "FirebaseQuickstarts",
-    "firebase_url": "https://mockproject-1234.firebaseio.com"
+    "project_number": "262311498471",
+    "firebase_url": "https://fir-quickstarts-a6494.firebaseio.com",
+    "project_id": "fir-quickstarts-a6494",
+    "storage_bucket": "fir-quickstarts-a6494.appspot.com"
   },
   "client": [
     {
       "client_info": {
-        "mobilesdk_app_id": "1:123456789000:android:f1bf012572b04063",
-        "client_id": "android:com.ezhome.rxfirebasedemo",
-        "client_type": 1,
+        "mobilesdk_app_id": "1:262311498471:android:c0c5789ae7945b59",
         "android_client_info": {
-          "package_name": "com.ezhome.rxfirebasedemo",
-          "certificate_hash": []
+          "package_name": "com.ezhome.rxfirebasedemo"
         }
       },
+      "oauth_client": [
+        {
+          "client_id": "262311498471-hu6pjbbkammkje369mpsslg849jtgmkq.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
       "api_key": [
         {
-          "current_key": ""
+          "current_key": "AIzaSyCAWOuIzhXl9WHsIQkDMO537Xn7moH_ICg"
         }
-      ]
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
     }
   ],
-  "client_info": [],
-  "ARTIFACT_VERSION": "1"
+  "configuration_version": "1"
 }

--- a/app/src/main/java/com/ezhome/rxfirebasedemo/PostsFragment.java
+++ b/app/src/main/java/com/ezhome/rxfirebasedemo/PostsFragment.java
@@ -66,7 +66,7 @@ public class PostsFragment extends Fragment {
    */
   private void loadPosts() {
     PostsFragment.this.showProgress(true);
-    RxFirebaseDatabase.getInstance().observeValueEvent(firebaseRef).subscribe(new GetPostsSubscriber());
+    RxFirebaseDatabase.getInstance().observeValueEvent(firebaseRef.child("fireblog")).subscribe(new GetPostsSubscriber());
   }
 
   /**

--- a/rxfirebase/buildsystem/dependencies.gradle
+++ b/rxfirebase/buildsystem/dependencies.gradle
@@ -9,7 +9,7 @@ ext {
   firebaseVersion = '11.0.0'
 
   //RxJava
-  rxJavaVersion = '1.1.9'
+  rxJavaVersion = '1.3.3'
 
   //Test
   jUnitVersion = '4.12'

--- a/rxfirebase/src/main/java/com/ezhome/rxfirebase2/database/FirebaseDatabaseErrorFactory.java
+++ b/rxfirebase/src/main/java/com/ezhome/rxfirebase2/database/FirebaseDatabaseErrorFactory.java
@@ -8,6 +8,7 @@ import com.ezhome.rxfirebase2.exception.FirebaseNetworkErrorException;
 import com.ezhome.rxfirebase2.exception.FirebaseOperationFailedException;
 import com.ezhome.rxfirebase2.exception.FirebasePermissionDeniedException;
 import com.google.firebase.database.DatabaseError;
+import rx.Emitter;
 import rx.Subscriber;
 
 /**
@@ -21,31 +22,31 @@ public class FirebaseDatabaseErrorFactory {
   }
 
   /**
-   * This method add to subsriber the proper error according to the
+   * This method add to emitter the proper error according to the
    *
-   * @param subscriber {@link rx.Subscriber}
+   * @param emitter {@link rx.Emitter}
    * @param error {@link DatabaseError}
    * @param <T> generic subscriber
    */
-  static <T> void buildError(Subscriber<T> subscriber, DatabaseError error) {
+  static <T> void buildError(Emitter<T> emitter, DatabaseError error) {
     switch (error.getCode()) {
       case DatabaseError.INVALID_TOKEN:
-        subscriber.onError(new FirebaseInvalidTokenException(error.getMessage()));
+        emitter.onError(new FirebaseInvalidTokenException(error.getMessage()));
         break;
       case DatabaseError.EXPIRED_TOKEN:
-        subscriber.onError(new FirebaseExpiredTokenException(error.getMessage()));
+        emitter.onError(new FirebaseExpiredTokenException(error.getMessage()));
         break;
       case DatabaseError.NETWORK_ERROR:
-        subscriber.onError(new FirebaseNetworkErrorException(error.getMessage()));
+        emitter.onError(new FirebaseNetworkErrorException(error.getMessage()));
         break;
       case DatabaseError.PERMISSION_DENIED:
-        subscriber.onError(new FirebasePermissionDeniedException(error.getMessage()));
+        emitter.onError(new FirebasePermissionDeniedException(error.getMessage()));
         break;
       case DatabaseError.OPERATION_FAILED:
-        subscriber.onError(new FirebaseOperationFailedException(error.getMessage()));
+        emitter.onError(new FirebaseOperationFailedException(error.getMessage()));
         break;
       default:
-        subscriber.onError(new FirebaseGeneralException(error.getMessage()));
+        emitter.onError(new FirebaseGeneralException(error.getMessage()));
         break;
     }
   }


### PR DESCRIPTION
Support backpressure to RxFirebaseDatabase

- Update rxJava library from 1.1.9 to 1.3.3
- Update firebase datastore schema
- Add new API with backpressure support:

Added methods:
```
observeValueEvent(final Query firebaseRef, Emitter.BackpressureMode backPressureMode);
observeSingleValue(final Query firebaseRef, Emitter.BackpressureMode backPressureMode);
observeChildEvent(final Query firebaseRef, Emitter.BackpressureMode backPressureMode);
```

These methods support `Emitter.BackpressureMode.BUFFER` by default:

```
observeValueEvent(final Query firebaseRef);
observeSingleValue(final Query firebaseRef);
observeChildEvent(final Query firebaseRef);
```
